### PR TITLE
Fix context leaking and hangs on invalid packet.

### DIFF
--- a/vorbis/src/main/java/de/jarnbjo/vorbis/AudioPacket.java
+++ b/vorbis/src/main/java/de/jarnbjo/vorbis/AudioPacket.java
@@ -40,7 +40,7 @@ class AudioPacket {
     final private Floor[] channelFloors;
     final private boolean[] noResidues;
 
-    private final static float[][] windows = new float[8][];
+    private final float[][] windows = new float[8][];
 
     protected AudioPacket(
             final VorbisStream vorbis, final BitInputStream source)

--- a/vorbis/src/main/java/de/jarnbjo/vorbis/VorbisStream.java
+++ b/vorbis/src/main/java/de/jarnbjo/vorbis/VorbisStream.java
@@ -51,7 +51,6 @@ public class VorbisStream {
     private static final int SETUP_HEADER = 5;
 
     final private Object streamLock = new Object();
-    private int pageCounter = 0;
 
     private int currentBitRate = 0;
 
@@ -157,11 +156,11 @@ public class VorbisStream {
     }
 
     private AudioPacket getNextAudioPacket() throws IOException {
-        pageCounter++;
-        byte[] data = oggStream.getNextOggPacket();
         AudioPacket res = null;
+        byte[] data = null;
         while (res == null) {
             try {
+                data = oggStream.getNextOggPacket();
                 res = new AudioPacket(this, new ByteArrayBitInputStream(data));
             } catch (ArrayIndexOutOfBoundsException e) {
                 // ignore and continue with next packet


### PR DESCRIPTION
This is a possible patch for the issue described here: https://github.com/jMonkeyEngine/jmonkeyengine/issues/2063
This was found with trial & error, i am not 101% confident of the validity of this patch, but it seems to solve the problem.