### PR TITLE
Service provider configuration file for VorbisAudioFileReader

### DIFF
--- a/vorbis/src/main/resources/META-INF/services/javax.sound.sampled.spi.AudioFileReader
+++ b/vorbis/src/main/resources/META-INF/services/javax.sound.sampled.spi.AudioFileReader
@@ -1,0 +1,1 @@
+de.jarnbjo.vorbis.VorbisAudioFileReader


### PR DESCRIPTION
Hi,

The Java Sound SPI configuration file is missing for `VorbisAudioFileReader`, adding it allows one to simply drop the jar on the classpath to add Ogg Vorbis support to `AudioSystem.getAudioInputStream()`.